### PR TITLE
Add DirtyUnicorns to list of supported Gerrits.

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -23,6 +23,7 @@
         <item>AOSP</item>
         <item>CarbonROM</item>
         <item>CyanogenMod</item>
+        <item>DirtyUnicorns</item>
         <item>Gerrit Review</item>
         <item>LiquidSmooth</item>
         <item>MerkMod</item>
@@ -40,6 +41,7 @@
         <item>https://android-review.googlesource.com/</item>
         <item>https://review.carbonrom.org/</item>
         <item>http://review.cyanogenmod.org/</item>
+        <item>http://gerrit.dirtyunicorns.com</item>
         <item>https://gerrit-review.googlesource.com/</item>
         <item>http://gerrit.liquidsmooth.net</item>
         <item>http://review.merkmod.com/</item>


### PR DESCRIPTION
http://gerrit.dirtyunicorns.com. This was working when I tested it last week, now their server seems to be down.