### PR TITLE
Update SlimRoms gerrit url

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -51,7 +51,7 @@
         <item>http://review.pac-rom.com/</item>
         <item>https://gerrit.paranoidandroid.co/</item>
         <item>http://review.gummyrom.com/</item>
-        <item>https://gerrit.slimroms.net</item>
+        <item>https://review.slimroms.org</item>
         <item>https://gerrit.wikimedia.org/r/</item>
         <item>https://review.openstack.org/</item>
     </string-array>


### PR DESCRIPTION
official domain is now slimroms.org