### PR TITLE
Diff Viewer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ gradle/daemon/
 *.*~
 .DS_Store
 private.creds
+buildSrc/local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 
     compile 'com.anupcowkur:reservoir:2.1'
 
-    compile('com.mikepenz:materialdrawer:5.0.0@aar') {
+    compile('com.mikepenz:materialdrawer:5.0.5@aar') {
         transitive = true
         exclude module: 'appcompat-v7'
     }

--- a/app/src/main/java/com/jbirdvegas/mgerrit/activities/DiffViewer.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/activities/DiffViewer.java
@@ -285,7 +285,6 @@ public class DiffViewer extends BaseDrawerActivity
         if (cursorLoader.getId() == LOADER_DIFF) {
             mAdapter.swapCursor(cursor);
             if (cursor != null && cursor.isAfterLast()) {
-                //if (request != null) request.cancel(); TODO: What was this doing?
                 mDiffTextView.setText(getString(R.string.diff_no_files));
             }
 
@@ -326,7 +325,7 @@ public class DiffViewer extends BaseDrawerActivity
         }
     }
 
-    @Keep @Subscribe(threadMode = ThreadMode.MAIN)
+    @Keep @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onImageLoaded(ImageLoaded ev) {
         Bitmap bitmap = ev.getImage();
         String filePath = ev.getFilePath();

--- a/app/src/main/java/com/jbirdvegas/mgerrit/activities/DiffViewer.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/activities/DiffViewer.java
@@ -114,6 +114,7 @@ public class DiffViewer extends BaseDrawerActivity
     public static final String FILE_PATH_TAG = "file";
 
     private static final String _DIFF_TEXT_TAG = "diff_text";
+    private static final String _DIFF_STATE = "diff_state";
     private EventBus mEventBus;
 
     private enum DiffType { Loading, Text, Image }
@@ -144,6 +145,7 @@ public class DiffViewer extends BaseDrawerActivity
         mDiffTextView = (DiffTextView) findViewById(R.id.diff_view_diff);
         mSpinner = (Spinner) findViewById(R.id.diff_spinner);
         mSwitcher = (ViewFlipper) findViewById(R.id.diff_switcher);
+        mSwitcher.setDisplayedChild(DiffType.Loading.ordinal());
 
         mBtnPrevious = (ImageButton) findViewById(R.id.diff_previous);
         mBtnNext = (ImageButton) findViewById(R.id.diff_next);
@@ -251,6 +253,7 @@ public class DiffViewer extends BaseDrawerActivity
         if (outState == null) outState = new Bundle();
         outState.putString(FILE_PATH_TAG, mFilePath);
         outState.putInt(PATCH_SET_NUMBER_TAG, mPatchsetNumber);
+        outState.putInt(_DIFF_STATE, mSwitcher.getDisplayedChild());
 
         if (isDisplayedView(DiffType.Text)) {
             outState.putCharSequence(_DIFF_TEXT_TAG, mDiffTextView.getText());
@@ -268,6 +271,8 @@ public class DiffViewer extends BaseDrawerActivity
         if (text != null) {
             mDiffTextView.setText(text);
             switchViews(DiffType.Text);
+        } else {
+            mSwitcher.setDisplayedChild(savedInstanceState.getInt(_DIFF_STATE, 0));
         }
     }
 

--- a/app/src/main/java/com/jbirdvegas/mgerrit/message/ChangeDiffLoaded.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/message/ChangeDiffLoaded.java
@@ -23,11 +23,23 @@ import com.jbirdvegas.mgerrit.objects.GerritMessage;
 public class ChangeDiffLoaded extends GerritMessage {
 
     private final String mChangeDiff;
+    private final int mChangeNumber;
+    private final int mPatchsetNumber;
 
-    public ChangeDiffLoaded(Intent intent, int queueId, String changeDiff) {
+    public ChangeDiffLoaded(Intent intent, int queueId, String changeDiff, int changeNo, int patchsetNo) {
         super(intent, queueId);
         this.mChangeDiff = changeDiff;
+        this.mChangeNumber = changeNo;
+        this.mPatchsetNumber = patchsetNo;
     }
 
     public String getDiff() { return mChangeDiff; }
+
+    public int getChangeNumber() {
+        return mChangeNumber;
+    }
+
+    public int getPatchsetNumber() {
+        return mPatchsetNumber;
+    }
 }

--- a/app/src/main/java/com/jbirdvegas/mgerrit/tasks/ImageProcessor.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/tasks/ImageProcessor.java
@@ -58,7 +58,7 @@ public class ImageProcessor extends SyncProcessor<Bitmap> {
         /* We don't store images in the database -send out a message instead when we
          * have finished loading it.
          * TODO Cache responses. */
-        EventBus.getDefault().post(new ImageLoaded(getIntent(), getQueueId(), data));
+        EventBus.getDefault().postSticky(new ImageLoaded(getIntent(), getQueueId(), data));
         return 1;
     }
 

--- a/app/src/main/java/com/jbirdvegas/mgerrit/tasks/ImageProcessor.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/tasks/ImageProcessor.java
@@ -126,4 +126,9 @@ public class ImageProcessor extends SyncProcessor<Bitmap> {
         Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, decodeOptions);
         return bitmap;
     }
+
+    /* This is a custom endpoint not part of the Gerrit api, so it doesn't handle authentication */
+    protected boolean isAuthenticationSupported() {
+        return false;
+    }
 }

--- a/app/src/main/java/com/jbirdvegas/mgerrit/tasks/SyncProcessor.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/tasks/SyncProcessor.java
@@ -160,7 +160,7 @@ abstract class SyncProcessor<T> {
         GerritAuthData.Basic authData;
         String username = null, password = null;
 
-        if (isAuthenticating) {
+        if (isAuthenticating && isAuthenticationSupported()) {
             username = intent.getStringExtra(GerritService.HTTP_USERNAME);
             password = intent.getStringExtra(GerritService.HTTP_PASSWORD);
             if (username == null || password == null) {
@@ -203,6 +203,15 @@ abstract class SyncProcessor<T> {
         if (lastSync == 0) return false; // Always sync if this is the first time
         long timeNow = System.currentTimeMillis();
         return ((timeNow - lastSync) < syncInterval);
+    }
+
+    /**
+     * Whether authentication is supported for this processor. If false, all requests will be
+     *  unauthenticated regardless of whether the user has signed in
+     * @return Whether authentication is supported for this processor.
+     */
+    protected boolean isAuthenticationSupported() {
+        return true;
     }
 
     public void cancelOperation() {

--- a/app/src/main/java/com/jbirdvegas/mgerrit/tasks/TextDiffProcessor.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/tasks/TextDiffProcessor.java
@@ -45,10 +45,9 @@ public class TextDiffProcessor extends SyncProcessor<String> {
 
     @Override
     int insert(String data) {
-        /* We don't store change diffs in the database -send out a message instead when we
-         * have finished loading it.
-         * TODO Cache responses. */
-        EventBus.getDefault().post(new ChangeDiffLoaded(getIntent(), getQueueId(), data));
+        /* We don't store change diffs in the database - send out a message instead when we
+         * have finished loading it. */
+        EventBus.getDefault().postSticky(new ChangeDiffLoaded(getIntent(), getQueueId(), data, mChangeNumber, mPatchsetNumber));
         return 1;
     }
 
@@ -90,7 +89,10 @@ public class TextDiffProcessor extends SyncProcessor<String> {
         return decodedContent;
     }
 
-    // Save the decoded diff text to the cache
+    /* Save the decoded diff text to the cache.
+     * This is pretty important as we fetch the diff for all text files in the change, but
+     * will only display one file at a time. Hence, requesting other files in the change will
+     * result in a cache hit instead of another query. */
     void doPostProcess(String data) {
         CacheManager.put(CacheManager.getDiffKey(mChangeNumber, mPatchsetNumber), data, false);
         /* Cleanup diffs for any superceeded revisions of this change as we will never attempt

--- a/app/src/main/java/com/jbirdvegas/mgerrit/views/DiffTextView.java
+++ b/app/src/main/java/com/jbirdvegas/mgerrit/views/DiffTextView.java
@@ -99,6 +99,10 @@ public class DiffTextView extends TextView {
         }
     }
 
+    public boolean hasDiff() {
+        return this.length() > 0;
+    }
+
     @Contract("null -> null")
     protected SpannableString spanColoredText(String incoming) {
         if (incoming == null) return null;

--- a/app/src/main/res/layout/commit_list.xml
+++ b/app/src/main/res/layout/commit_list.xml
@@ -34,6 +34,5 @@
         android:scrollbarStyle="outsideInset"
         android:paddingBottom="@dimen/cards_list_padding_vert"
         android:paddingLeft="@dimen/cards_list_padding_horiz"
-        android:paddingTop="@dimen/cards_list_padding_vert"
         android:drawSelectorOnTop="true"/>
 </android.support.v4.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/refine_search_card.xml
+++ b/app/src/main/res/layout/refine_search_card.xml
@@ -16,27 +16,45 @@
   ~  limitations under the License.
   -->
 
+<!-- Wrap the layout inside a FrameLayout so we can toggle its visibility instead of adding/removing
+ the header view -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/clickableCardBackground"
-    android:elevation="@dimen/z_offset_medium"
-    android:orientation="horizontal"
-    android:padding="@dimen/standard_padding">
+    android:id="@+id/refine_search_container"
+    android:orientation="vertical">
 
-    <TextView
-        style="?attr/cardTextStyle"
-        android:layout_width="wrap_content"
+    <!-- Hack to remove the permanent blank space at the top of the view, but keep some padding
+      when the refine search card is showing -->
+    <View
+        android:id="@+id/blank_list_divider"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/standard_padding"
+        android:background="?attr/mainBackgroundColor"/>
+
+    <LinearLayout
+        android:id="@+id/refine_search_wrapper"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/refine_search_title" />
+        android:elevation="@dimen/z_offset_medium"
+        android:orientation="horizontal"
+        android:padding="@dimen/standard_padding"
+        android:background="?attr/clickableCardBackground">
 
-    <TextView
-        android:id="@+id/txtRefineSearchKeywordCount"
-        style="?attr/cardTextStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/standard_padding"
-        tools:text="@string/refine_search_num_keywords" />
+        <TextView
+            style="?attr/cardTextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/refine_search_title"/>
 
+        <TextView
+            android:id="@+id/txtRefineSearchKeywordCount"
+            style="?attr/cardTextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="@dimen/standard_padding"
+            tools:text="@string/refine_search_num_keywords" />
+
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -26,6 +26,7 @@
         <item name="appBarTheme">@style/NoActionBar.AppBarOverlay</item>
         <item name="toolbarTheme">@style/NoActionBar.PopupOverlay</item>
         <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
 
         <item name="gerritIcon">@drawable/ic_menu_source</item>
         <item name="projectsIcon">@drawable/ic_menu_project</item>
@@ -78,6 +79,7 @@
         <item name="appBarTheme">@style/NoActionBar.AppBarOverlay.Dark</item>
         <item name="toolbarTheme">@style/NoActionBar.PopupOverlay.Dark</item>
         <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
 
         <item name="gerritIcon">@drawable/ic_menu_source_dark</item>
         <item name="projectsIcon">@drawable/ic_menu_project_dark</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -25,6 +25,7 @@
         <item name="appBarTheme">@style/NoActionBar.AppBarOverlay</item>
         <item name="toolbarTheme">@style/NoActionBar.PopupOverlay</item>
         <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
 
         <item name="gerritIcon">@drawable/ic_menu_source</item>
         <item name="projectsIcon">@drawable/ic_menu_project</item>
@@ -66,12 +67,13 @@
         <item name="material_drawer_background">@color/card_background</item>
     </style>
 
-    <style name="Theme.Dark" parent="Theme.AppCompat">
+    <style name="Theme.Dark" parent="MaterialDrawerTheme">
         <item name="android:textColorPrimary">@color/actionbar_text_dark</item>
         <item name="android:actionOverflowButtonStyle">@style/OverFlow.Dark</item>
         <item name="appBarTheme">@style/NoActionBar.AppBarOverlay.Dark</item>
         <item name="toolbarTheme">@style/NoActionBar.PopupOverlay.Dark</item>
         <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
 
         <item name="gerritIcon">@drawable/ic_menu_source_dark</item>
         <item name="projectsIcon">@drawable/ic_menu_project_dark</item>


### PR DESCRIPTION
Fix a number of issues around the Diff Viewer, mainly around viewing text:
- Save and restore the diff text when configuration changes
- Don't discard the results of fetching diff text and images during a configuration change
- Fix not being able to view images in DiffViewer while signed in
- Fix changes with a duplicate change id not loading (again)
- Fix adding the refine search card for Android KK and below

refs #47, #48
